### PR TITLE
Add data to onStepChange function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ At react-losen, we use the following tools:
 - [Prettier](https://prettier.io/) for code formatting
 - [Eslint](https://eslint.org/) for linting
 
-## Api Reference
+## API reference
 
 * `Wizard`, the main orchestrator. It has 2 required props 
     - render: This takes a set of `Step` as children. Minumum 2. Start and end
     - onComplete: What to do when the Wizard is complete.
+    - onStepChange is called each time the step changes. This function is not called on initial load.
 * `Step`, a wrapper for what you want to show as a step. It registers the step on mount to the Wizard context
 * `Controls`, the controller for which step to show next. Has 2 directions: next and previous. It also knows if you are on the last or first step.
 

--- a/index.js
+++ b/index.js
@@ -136,7 +136,13 @@ class Wizard extends React.Component {
               const prevStepName = activeStep.name;
               const nextStepName = steps[nextStep].name;
               if (onStepChange && !steps[nextStep].autoSkip) {
-                onStepChange(prevStepName, nextStepName, stepData);
+                onStepChange({
+                  prevStepName,
+                  nextStepIndex: nextStep,
+                  nextStepName,
+                  numSteps: steps.length,
+                  stepData
+                });
               }
 
               _this.setState({
@@ -270,9 +276,9 @@ Controls.contextTypes = {
 };
 
 var entry = {
-    Wizard,
-    Step,
-    Controls
+  Wizard,
+  Step,
+  Controls
 };
 
 module.exports = entry;

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -18,13 +18,17 @@ const emptyStep = {
   autoSkip: null,
 };
 
+export type OnStepChangeType = {
+  nextStepIndex: number,
+  nextStepName: string,
+  numSteps: number,
+  prevStepName: string,
+  stepData: Object,
+};
+
 type Props = {
   onComplete: (wizardData: Object, currentStep: string) => void,
-  onStepChange?: (
-    prevStepName: string,
-    nextStepName: string,
-    stepData: Object,
-  ) => void,
+  onStepChange: OnStepChangeType => void,
   debug?: boolean,
   render: (stepData: Object, func: OnPartialChange) => Node,
   onError?: (error: Object) => void,
@@ -127,7 +131,13 @@ class Wizard extends Component<Props, State> {
             const prevStepName = activeStep.name;
             const nextStepName = steps[nextStep].name;
             if (onStepChange && !steps[nextStep].autoSkip) {
-              onStepChange(prevStepName, nextStepName, stepData);
+              onStepChange({
+                prevStepName,
+                nextStepIndex: nextStep,
+                nextStepName,
+                numSteps: steps.length,
+                stepData,
+              });
             }
 
             this.setState(
@@ -144,7 +154,7 @@ class Wizard extends Component<Props, State> {
             );
           }
         } catch (error) {
-          if(this.props.onError) {
+          if (this.props.onError) {
             this.props.onError(error);
           }
         }


### PR DESCRIPTION
- numStep and nextStepIndex is added to avoid forcing the user to couple
  logic to step names.
- `onStepChange` is now called with an object, making it easier for the
  consumer to use, and easier to refactor and change the API.