### PR TITLE
Rix1/update from user feedback

### DIFF
--- a/pages/components/InputComponent.js
+++ b/pages/components/InputComponent.js
@@ -1,10 +1,20 @@
 // @flow
 import React, { useState } from 'react';
 
-const InputComponent = () => {
+type Props = {
+  name: String,
+};
+
+const InputComponent = ({ name }: Props) => {
   const [text, setText] = useState('');
-  console.log('InputComponent says hi');
-  return <textarea value={text} onChange={ev => setText(ev.target.value)} />;
+  return (
+    <textarea
+      className="w-100 h3"
+      placeholder={name}
+      value={text}
+      onChange={ev => setText(ev.target.value)}
+    />
+  );
 };
 
 export default InputComponent;

--- a/pages/components/StepWithInput.js
+++ b/pages/components/StepWithInput.js
@@ -6,9 +6,10 @@ import { Step } from '../../src';
 const StepWithInput = () => {
   const [text, setText] = useState('');
   return (
-    <Step name="StepWithInput">
+    <Step name="step 3">
       <textarea
-        placeholder={`Write something to ${StepWithInput}`}
+        className="w-100 h3"
+        placeholder="Step 3: Write something"
         value={text}
         onChange={ev => setText(ev.target.value)}
       />

--- a/pages/components/WizardExample.js
+++ b/pages/components/WizardExample.js
@@ -6,6 +6,14 @@ import Controls from './Controls';
 import InputComponent from './InputComponent';
 import StepWithInput from './StepWithInput';
 
+const someAsyncFunc = () =>
+  new Promise(res =>
+    setTimeout(() => {
+      console.log('inner timeout done');
+      res();
+    }, 800),
+  );
+
 const WizardExample = () => {
   const [stepEnabled, setEnabledStep] = useState(true);
   const [passValidation, setPassValidation] = useState(true);
@@ -17,33 +25,28 @@ const WizardExample = () => {
     <>
       <Wizard onComplete={onComplete} debug>
         <div>
-          <Step name="1">
+          <Step
+            name="step 1"
+            validator={() => {
+              console.log('validator done');
+            }}>
             <p className="f3 tc">First step</p>
           </Step>
           <Step
-            name="2"
+            name="step 2"
             autoSkip={!stepEnabled}
-            validator={(resolve, reject) =>
-              setTimeout(() => {
-                if (passValidation) {
-                  resolve();
-                } else {
-                  reject(new ValidationError('Not ready to continue'));
-                }
-              }, 800)
-            }>
-            <InputComponent />
+            validator={async () => {
+              await someAsyncFunc();
+              console.log('waiting for timeout done');
+            }}>
+            <InputComponent name="step 2" />
           </Step>
 
           <StepWithInput />
 
           <Step
-            name="3"
-            validator={resolve =>
-              setTimeout(() => {
-                resolve();
-              }, 800)
-            }>
+            name="step 4"
+            validator={() => new Promise(res => setTimeout(() => res(), 800))}>
             <p className="f3 tc">Third step</p>
           </Step>
         </div>

--- a/src/Step.js
+++ b/src/Step.js
@@ -28,7 +28,7 @@ const Step = ({ children, name, validator, autoSkip }: Props) => {
     if (initialized) {
       updateStep(stepInfo);
     }
-  }, [autoSkip]);
+  }, [autoSkip, validator]);
 
   if (activeStep.name !== name) {
     return null;

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -39,14 +39,14 @@ const Wizard = ({ children, onComplete, debug }: Props) => {
     const next = findNextValid(steps, index);
 
     const nextAction =
-      findNextValid(steps, index) === index
+      next === index
         ? () => onComplete(steps[index].name)
         : () => setIndex(next);
 
     if (validator) {
       try {
         setLoadingState(true);
-        await new Promise(validator);
+        await validator();
         nextAction();
       } catch (error) {
         if (error instanceof ValidationError) {


### PR DESCRIPTION
I changed how we invoke the validator function: it no longer creates a promise, but it's still supports async validators.

Also did some performance/re-render testing with input fields and local state. I found some caveats that should be documented in the API docs. Based on this I reverted the commit  that required the validator function to be set only once (on initial render). This probably doesn't make any sense right now, but will hopefully be more clear when I write the docs.

## Todo 

- [ ] ~Document caveats with validator functions and re-renders.~ Added issue #19 