### PR TITLE
Fix bug where back/forward browser buttons do not refresh Wizard content

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "eslint . --cache",
     "dev": "docz dev",
     "test": "jest --setupTestFrameworkScriptFile=./setupJest.js",
-    "tdd": "jest --watch",
+    "tdd": "jest --setupTestFrameworkScriptFile=./setupJest.js --watch",
     "build": "pack build",
     "publish": "pack publish"
   },

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
 import { findNextValid, findPreviousValid } from './utils';
 import { ControlsContext } from './Controls';
@@ -80,20 +80,27 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
     }
   }
 
+  const onLoad = useCallback(() => {
+    if (stateManager) {
+      const activeStep = stateManager.getActiveStep();
+      let activeIndex = steps.findIndex(step => step.name === activeStep);
+      activeIndex = activeIndex > -1 ? activeIndex : 0;
+      setIndex(activeIndex);
+    }
+  }, [stateManager, steps]);
+
   useEffect(() => {
     // for debugging purposes only
     if (debug) {
       console.debug('steps updated', steps); // eslint-disable-line
     }
 
-    if (stateManager) {
-      const activeStep = stateManager.getActiveStep();
-      const activeIndex = steps.findIndex(step => step.name === activeStep);
-      if (activeIndex > -1) {
-        setIndex(activeIndex);
-      }
-    }
-  }, [steps, debug, stateManager]);
+    window.addEventListener('popstate', () => {
+      onLoad();
+    });
+
+    onLoad();
+  }, [steps, debug, stateManager, onLoad]);
 
   return (
     <ControlsContext.Provider

--- a/src/Wizard.test.js
+++ b/src/Wizard.test.js
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import Wizard from './Wizard';
 import Step from './Step';
@@ -61,10 +60,6 @@ describe('Wizard', () => {
 });
 
 describe('Wizard caches step state in url', () => {
-  const map = {};
-  window.addEventListener = jest.fn((event, cb) => {
-    map[event] = cb;
-  });
   let component;
 
   beforeEach(() => {


### PR DESCRIPTION
### Fixes bug where back/forward browser buttons do not refresh the Wizard.

Was not reproduced on advanced example app (when running yarn dev in repo).

![buggy](https://user-images.githubusercontent.com/31858814/72059951-4bd59c00-32d3-11ea-8346-80139de1d468.gif)

Repro steps:
1. Run wizard.
2. Navigate to step 2.
3. Press browser back button

**Actual behaviour:** URL changes to reflect step 1 but wizard content remains at step 2.

**Expected behaviour:** URL and wizard content changes to reflect step 1.

### How does this fix work?
Added an event listener to the "popstate" event which is triggered on backwards and forwards. This event listener sets the active step, triggering a re-render and updating the step.

### Considerations:
Adding custom events in react apps is not really desirable, this could mess up the react lifecycle. I can't really think of any other solutions to this problem though. We could force consumer apps to pass in a "current route" prop, and run useEffect when the route is changed, but this complicates the Wizard api.

![works](https://user-images.githubusercontent.com/31858814/72059966-56903100-32d3-11ea-9d77-ade89fddacc6.gif)
