### PR TITLE
Cache step state in url manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ import { Wizard, Step, Controls } from 'react-losen';
 Include the following polyfills to support older browsers:
 - `array-findindex-polyfill`
 - `url-search-params-polyfill`
+- `Object.entries` polyfill
 
 ### Developing
 

--- a/flow-typed/StateManager.js
+++ b/flow-typed/StateManager.js
@@ -3,4 +3,6 @@
 export type Losen$StateManager = {|
   updateStep: (currentStepName: string, nextStepName: string) => void,
   getActiveStep: () => int,
+  getItem: (key: string) => string,
+  setItem: (key: string, value: string) => void,
 |};

--- a/flow-typed/WizardTypes.js
+++ b/flow-typed/WizardTypes.js
@@ -5,8 +5,9 @@ export type Losen$Direction = ?Losen$StepTypes;
 
 export type Losen$ValidatorFunction = () => Promise<React$Node>;
 
-declare type Losen$Step = {
+declare type Losen$Step = {|
   name: string,
   validator: ?Losen$ValidatorFunction,
   autoSkip: ?boolean,
-};
+  state: ?Array<{| [string]: string |}>,
+|};

--- a/src/Step.js
+++ b/src/Step.js
@@ -36,13 +36,13 @@ const Step = ({ children, name, validator, autoSkip, state }: Props) => {
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoSkip, validator, initialized]);
+  }, [name, autoSkip, validator, initialized]); // adding all deps causes infinite reloads - to be fixed later!
 
   useEffect(() => {
     if (state && stateManager) {
       state.forEach(item => {
-        const key = Object.keys(item)[0];
-        stateManager.setItem(key, item[key]);
+        const [key, value] = Object.entries(item)[0];
+        stateManager.setItem(key, value);
       });
     }
   }, [state, stateManager]);
@@ -57,7 +57,7 @@ const Step = ({ children, name, validator, autoSkip, state }: Props) => {
 Step.defaultProps = {
   validator: null,
   autoSkip: false,
-  state: undefined,
+  state: null,
 };
 
 export default Step;

--- a/src/Step.js
+++ b/src/Step.js
@@ -17,25 +17,26 @@ const Step = ({ children, name, validator, autoSkip, state }: Props) => {
     stateManager,
   } = useContext(StepContext);
 
-  const stepInfo = {
-    name,
-    validator,
-    autoSkip,
-  };
-
   useEffect(() => {
     if (!initialized) {
-      registerStep(stepInfo);
+      registerStep({
+        name,
+        validator,
+        autoSkip,
+      });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name]);
+  }, [name, validator, autoSkip, initialized, registerStep]);
 
   useEffect(() => {
     if (initialized) {
-      updateStep(stepInfo);
+      updateStep({
+        name,
+        validator,
+        autoSkip,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoSkip, validator]);
+  }, [autoSkip, validator, initialized]);
 
   useEffect(() => {
     if (state && stateManager) {

--- a/src/Step.js
+++ b/src/Step.js
@@ -3,14 +3,19 @@ import { useEffect, createContext, useContext } from 'react';
 
 export const StepContext = createContext<Object>(null);
 
-type Props = {
+type Props = {|
   children: React$Node,
-} & Losen$Step;
+  ...Losen$Step,
+|};
 
-const Step = ({ children, name, validator, autoSkip }: Props) => {
-  const { registerStep, activeStep, updateStep, initialized } = useContext(
-    StepContext,
-  );
+const Step = ({ children, name, validator, autoSkip, state }: Props) => {
+  const {
+    registerStep,
+    activeStep,
+    updateStep,
+    initialized,
+    stateManager,
+  } = useContext(StepContext);
 
   const stepInfo = {
     name,
@@ -22,13 +27,24 @@ const Step = ({ children, name, validator, autoSkip }: Props) => {
     if (!initialized) {
       registerStep(stepInfo);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
 
   useEffect(() => {
     if (initialized) {
       updateStep(stepInfo);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoSkip, validator]);
+
+  useEffect(() => {
+    if (state && stateManager) {
+      state.forEach(item => {
+        const key = Object.keys(item)[0];
+        stateManager.setItem(key, item[key]);
+      });
+    }
+  }, [state, stateManager]);
 
   if (activeStep.name !== name) {
     return null;
@@ -40,6 +56,7 @@ const Step = ({ children, name, validator, autoSkip }: Props) => {
 Step.defaultProps = {
   validator: null,
   autoSkip: false,
+  state: undefined,
 };
 
 export default Step;

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -125,6 +125,7 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
           activeStep: steps[index] || {},
           initialized: !!steps[index],
           updateStep,
+          stateManager,
         }}>
         {children}
       </StepContext.Provider>

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -15,7 +15,7 @@ type Props = {|
 |};
 
 const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useState<number | null>(null);
   const [steps, setSteps] = useState<Array<Losen$Step>>([]);
   const [isLoading, setLoadingState] = useState(false);
 
@@ -36,6 +36,9 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
   }
 
   async function onNext() {
+    if (index === null) {
+      return;
+    }
     const { validator } = steps[index];
     const next = findNextValid(steps, index);
 
@@ -72,7 +75,7 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
   }
 
   function onPrevious() {
-    if (index === 0) {
+    if (index === null) {
       return;
     }
     const prev = findPreviousValid(steps, index);
@@ -91,10 +94,12 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
     if (stateManager) {
       const activeStep = stateManager.getActiveStep();
       let activeIndex = steps.findIndex(step => step.name === activeStep);
-      activeIndex = activeIndex > -1 ? activeIndex : 0;
+      activeIndex = activeIndex > -1 ? activeIndex : null;
       setIndex(activeIndex);
+    } else if (index === null) {
+      setIndex(0);
     }
-  }, [stateManager, steps]);
+  }, [index, stateManager, steps]);
 
   useEffect(() => {
     // for debugging purposes only
@@ -115,15 +120,16 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
         onNext,
         onPrevious,
         isLoading,
-        isFirst: findPreviousValid(steps, index) === index,
-        isLast: findNextValid(steps, index) === index,
+        isFirst:
+          index !== null ? findPreviousValid(steps, index) === index : false,
+        isLast: index !== null ? findNextValid(steps, index) === index : false,
         activeIndex: index,
       }}>
       <StepContext.Provider
         value={{
           registerStep,
-          activeStep: steps[index] || {},
-          initialized: !!steps[index],
+          activeStep: index === null ? { name: '' } : steps[index],
+          initialized: index === null ? false : !!steps[index],
           updateStep,
           stateManager,
         }}>

--- a/src/Wizard.test.js
+++ b/src/Wizard.test.js
@@ -80,9 +80,7 @@ describe('Wizard caches step state in url', () => {
   test('url changes upon click of next button', () => {
     component.find('#next-button').simulate('click');
     expect(component.find('#active-step').text()).toBe('Step two');
-    const searchParams = new URLSearchParams(
-      new URL(window.location.href).searchParams,
-    );
+    const { searchParams } = new URL(window.location.href);
     expect(searchParams.get('step')).toBe('two');
   });
 });

--- a/src/Wizard.test.js
+++ b/src/Wizard.test.js
@@ -63,24 +63,24 @@ describe('Wizard caches step state in url', () => {
   let component;
 
   beforeEach(() => {
-    window.history.pushState({ activeStep: 'one' }, '', '?step=one');
+    window.history.pushState({ activeStep: 'two' }, '', '?step=two');
     component = mount(<WizardComponent stateManager={UrlStateManager} />);
   });
 
   test('renders correct step upon load', () => {
-    expect(component.find('#active-step').text()).toBe('Step one');
+    expect(component.find('#active-step').text()).toBe('Step two');
   });
 
   test('renders previous step on back button', () => {
-    window.history.pushState({ activeStep: 'two' }, '', '?step=two');
+    window.history.pushState({ activeStep: 'three' }, '', '?step=three');
     window.history.back();
-    expect(component.find('#active-step').text()).toBe('Step one');
+    expect(component.find('#active-step').text()).toBe('Step two');
   });
 
   test('url changes upon click of next button', () => {
     component.find('#next-button').simulate('click');
-    expect(component.find('#active-step').text()).toBe('Step two');
+    expect(component.find('#active-step').text()).toBe('Step three');
     const { searchParams } = new URL(window.location.href);
-    expect(searchParams.get('step')).toBe('two');
+    expect(searchParams.get('step')).toBe('three');
   });
 });

--- a/src/state-managers/url-state-manager.js
+++ b/src/state-managers/url-state-manager.js
@@ -1,16 +1,14 @@
 // @flow
 
 function setSearchParam(key: string, value: string) {
-  const searchParams = new URLSearchParams(
-    new URL(window.location.href).searchParams,
-  );
+  const { searchParams } = new URL(window.location.href);
   searchParams.set(key, value);
   return searchParams.toString() || '';
 }
 
 function getSearchParam(key: string) {
   const { href } = window.location;
-  const searchParams = new URLSearchParams(new URL(href).searchParams);
+  const { searchParams } = new URL(href);
   return searchParams.get(key) || '';
 }
 

--- a/src/state-managers/url-state-manager.js
+++ b/src/state-managers/url-state-manager.js
@@ -1,24 +1,50 @@
 // @flow
 
+function setSearchParam(key: string, value: string) {
+  const searchParams = new URLSearchParams(
+    new URL(window.location.href).searchParams,
+  );
+  searchParams.set(key, value);
+  return searchParams.toString() || '';
+}
+
+function getSearchParam(key: string) {
+  const { href } = window.location;
+  const searchParams = new URLSearchParams(new URL(href).searchParams);
+  return searchParams.get(key) || '';
+}
+
 export const UrlStateManager: Losen$StateManager = {
   updateStep: (currentStepName, nextStepName) => {
     const currentUrl = window.location.href;
     const basePath = currentUrl.includes('?')
       ? currentUrl.split('?')[0]
       : currentUrl;
-    const searchParams = new URLSearchParams(new URL(currentUrl).searchParams);
-    searchParams.set('step', nextStepName);
+    const searchParams = setSearchParam('step', nextStepName);
 
     window.history.pushState({ activeStep: currentStepName }, '', currentUrl);
     window.history.replaceState(
       { activeStep: nextStepName },
       '',
-      `${basePath}?${searchParams.toString()}`,
+      `${basePath}?${searchParams}`,
     );
   },
   getActiveStep: () => {
-    const { href } = window.location;
-    const searchParams = new URLSearchParams(new URL(href).searchParams);
-    return searchParams.get('step');
+    return getSearchParam('step');
+  },
+  getItem: (key: string) => {
+    return getSearchParam(key);
+  },
+  setItem: (key: string, value: string) => {
+    const searchParams = setSearchParam(key, value);
+    const currentUrl = window.location.href;
+    const basePath = currentUrl.includes('?')
+      ? currentUrl.split('?')[0]
+      : currentUrl;
+    window.history.replaceState(
+      { ...window.history.state, [key]: value },
+      '',
+      `${basePath}?${searchParams}`,
+    );
   },
 };


### PR DESCRIPTION
This PR enables the url-state-manager to set and get params in the url.
This can be used for caching user inputs.

Usage will look something like this pseudo code:
```
const inputValue = 'eee';
const otherValue = 'ccc';

<Wizard>
   <Step state={[{firstStepValue: inputValue}, {someOtherValue: otherValue}]}>
      <Input value={inputValue}">
      <Input value={otherValue}">
   </Step>
</Wizard>
```
The url search params will look something like:
```
?step=first&firstStepValue=eee&someOtherValue=ccc
```