### PR TITLE
Rix1/refactor context

### DIFF
--- a/pages/components/Controls.js
+++ b/pages/components/Controls.js
@@ -1,14 +1,13 @@
 // @flow
-import React, { useContext } from 'react';
-import { ControlsContext } from '../../src';
+import React from 'react';
+import { useActionContext, useStateContext } from '../../src';
 
 import Button from './Button';
 import Emoji from './Emoji';
 
 const Controls = () => {
-  const { onNext, onPrevious, isFirst, isLast, isLoading } = useContext(
-    ControlsContext,
-  );
+  const { isFirst, isLast, isLoading } = useStateContext();
+  const { onNext, onPrevious } = useActionContext();
   return (
     <div className="flex items-center justify-center pa4">
       <Button onClick={onPrevious} disabled={isLoading || isFirst}>

--- a/pages/components/StepOne.js
+++ b/pages/components/StepOne.js
@@ -1,0 +1,21 @@
+// @flow
+import React, { useEffect } from 'react';
+import { Step } from '../../src';
+
+const StepOne = () => {
+  useEffect(() => {
+    console.log('step 1 mounted');
+  }, []);
+
+  return (
+    <Step
+      name="step 1"
+      validator={() => {
+        console.log('validator done');
+      }}>
+      <p className="f3 tc">First step</p>
+    </Step>
+  );
+};
+
+export default StepOne;

--- a/pages/components/StepTwo.js
+++ b/pages/components/StepTwo.js
@@ -1,0 +1,29 @@
+// @flow
+import React, { useEffect } from 'react';
+import { Step } from '../../src';
+import InputComponent from './InputComponent';
+import { someAsyncFunc } from './asyncMock';
+
+type Props = {
+  stepEnabled: boolean,
+};
+
+const StepTwo = ({ stepEnabled }: Props) => {
+  useEffect(() => {
+    console.log('step 2 mounted');
+  }, []);
+
+  return (
+    <Step
+      name="step 2"
+      autoSkip={!stepEnabled}
+      validator={async () => {
+        await someAsyncFunc();
+        console.log('waiting for timeout done');
+      }}>
+      <InputComponent name="step 2" />
+    </Step>
+  );
+};
+
+export default StepTwo;

--- a/pages/components/StepWithInput.js
+++ b/pages/components/StepWithInput.js
@@ -1,10 +1,14 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Step } from '../../src';
 
 const StepWithInput = () => {
   const [text, setText] = useState('');
+
+  useEffect(() => {
+    console.log('step 3 mounted');
+  }, []);
   return (
     <Step name="step 3">
       <textarea

--- a/pages/components/WizardExample.js
+++ b/pages/components/WizardExample.js
@@ -4,16 +4,9 @@ import React, { useState } from 'react';
 import { Wizard, Step } from '../../src';
 import { UrlStateManager } from '../../src/state-managers/url-state-manager';
 import Controls from './Controls';
-import InputComponent from './InputComponent';
 import StepWithInput from './StepWithInput';
-
-const someAsyncFunc = () =>
-  new Promise(res =>
-    setTimeout(() => {
-      console.log('inner timeout done');
-      res();
-    }, 800),
-  );
+import StepOne from './StepOne';
+import StepTwo from './StepTwo';
 
 const WizardExample = () => {
   const [stepEnabled, setEnabledStep] = useState(true);
@@ -26,23 +19,8 @@ const WizardExample = () => {
     <>
       <Wizard onComplete={onComplete} stateManager={UrlStateManager} debug>
         <div>
-          <Step
-            name="step 1"
-            validator={() => {
-              console.log('validator done');
-            }}>
-            <p className="f3 tc">First step</p>
-          </Step>
-          <Step
-            name="step 2"
-            autoSkip={!stepEnabled}
-            validator={async () => {
-              await someAsyncFunc();
-              console.log('waiting for timeout done');
-            }}>
-            <InputComponent name="step 2" />
-          </Step>
-
+          <StepOne />
+          <StepTwo stepEnabled={stepEnabled} />
           <StepWithInput />
 
           <Step

--- a/pages/components/WizardExample.js
+++ b/pages/components/WizardExample.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useState } from 'react';
 
-import { Wizard, ValidationError, Step } from '../../src';
+import { Wizard, Step } from '../../src';
 import { UrlStateManager } from '../../src/state-managers/url-state-manager';
 import Controls from './Controls';
 import InputComponent from './InputComponent';

--- a/pages/components/asyncMock.js
+++ b/pages/components/asyncMock.js
@@ -1,0 +1,7 @@
+export const someAsyncFunc = () =>
+  new Promise(res =>
+    setTimeout(() => {
+      console.log('inner timeout done');
+      res();
+    }, 800),
+  );

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -1,7 +1,5 @@
 // @flow
-import { createContext, useContext } from 'react';
-
-export const ControlsContext = createContext<Object>(null);
+import { useActionContext, useStateContext } from './contexts';
 
 type Props = {|
   render: (
@@ -15,14 +13,8 @@ type Props = {|
 |};
 
 const Controls = ({ render }: Props) => {
-  const {
-    onNext,
-    onPrevious,
-    isFirst,
-    isLast,
-    isLoading,
-    activeIndex,
-  } = useContext(ControlsContext);
+  const { isFirst, isLast, isLoading, activeIndex } = useActionContext();
+  const { onNext, onPrevious } = useStateContext();
 
   return render(onNext, onPrevious, isFirst, isLast, isLoading, activeIndex);
 };

--- a/src/Step.js
+++ b/src/Step.js
@@ -1,7 +1,6 @@
 // @flow
-import { useEffect, createContext, useContext } from 'react';
-
-export const StepContext = createContext<Object>(null);
+import { useEffect } from 'react';
+import { useStateContext, useActionContext } from './contexts';
 
 type Props = {|
   children: React$Node,
@@ -9,13 +8,8 @@ type Props = {|
 |};
 
 const Step = ({ children, name, validator, autoSkip, state }: Props) => {
-  const {
-    registerStep,
-    activeStep,
-    updateStep,
-    initialized,
-    stateManager,
-  } = useContext(StepContext);
+  const { activeStep, initialized, stateManager } = useStateContext();
+  const { registerStep, updateStep } = useActionContext();
 
   useEffect(() => {
     if (!initialized) {

--- a/src/contexts.js
+++ b/src/contexts.js
@@ -1,0 +1,25 @@
+// @flow
+import { createContext, useContext } from 'react';
+
+export const StateContext = createContext<Object>(null);
+export const ActionContext = createContext<Object>(null);
+
+export function useStateContext() {
+  const context = useContext(StateContext);
+
+  if (context === 'undefined') {
+    throw new Error('useStateContext must be wrapped in a WizardProvider');
+  }
+
+  return context;
+}
+
+export function useActionContext() {
+  const context = useContext(ActionContext);
+
+  if (context === 'undefined') {
+    throw new Error('useActionContext must be wrapped in a WizardProvider');
+  }
+
+  return context;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,16 @@
 // @flow
-import Controls, { ControlsContext } from './Controls';
-import Step, { StepContext } from './Step';
-import Wizard, { ValidationError } from './Wizard';
 import { UrlStateManager } from './state-managers/url-state-manager';
+import { useStateContext, useActionContext } from './contexts';
+import Controls from './Controls';
+import Step from './Step';
+import Wizard, { ValidationError } from './Wizard';
 
 export {
   Controls,
-  ControlsContext,
   Step,
-  StepContext,
+  UrlStateManager,
+  useActionContext,
+  useStateContext,
   ValidationError,
   Wizard,
-  UrlStateManager,
 };


### PR DESCRIPTION
To avoid some issues with infinite loops and hacks, this PR refactors the Wizard Context:

- from ~`ControlsContext`~ -> `ActionsContext`
- from ~`StepContext`~ -> `StateContext`

~This avoids the issue of infinite loops without ignoring the `exhaustive deps` eslint rule.~ 
👉 Wrong. That issue is fixed in https://github.com/otovo/react-losen/pull/25

~I also experimented with how we can have a new prop `onReady()` that is called when the wizard is set up and state is initialized. This is PoC, and only accepts a debounced function (it's called on every render 😅) but something like this can be useful to log GA pageview events etc.~ 
👉Removed from this PR.

I'll continue my explorations in https://github.com/otovo/react-losen/pull/25.