### PR TITLE
Wizard supports addition of steps after initialize

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -28,11 +28,15 @@ const Wizard = ({ children, onComplete, stateManager, debug }: Props) => {
 
   function updateStep(step) {
     const stepIndex = steps.findIndex(el => el.name === step.name);
-    setSteps(previousSteps => [
-      ...previousSteps.slice(0, stepIndex),
-      step,
-      ...previousSteps.slice(stepIndex + 1),
-    ]);
+    if (stepIndex == -1) {
+      registerStep(step);
+    } else {
+      setSteps(previousSteps => [
+        ...previousSteps.slice(0, stepIndex),
+        step,
+        ...previousSteps.slice(stepIndex + 1),
+      ]);
+    }
   }
 
   async function onNext() {


### PR DESCRIPTION
This PR allows us to add to or remove Steps from the Wizard after first init.
This means that Wizards can be init with only one step and more steps can be added later.

Use case:
- Wizard is created with one step
- Based on the user choices made on step one, add x number of steps to the Wizard.

No tests have been added here since time is short and tests have not been updated in a while.
I'll update tests in another PR next week.