### PR TITLE
Improve error handling and add more event callbacks

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -35,7 +35,7 @@ const Wizard = ({
 
   function updateStep(step) {
     const stepIndex = steps.findIndex(el => el.name === step.name);
-    if (stepIndex == -1) {
+    if (stepIndex === -1) {
       registerStep(step);
     } else {
       setSteps(previousSteps => [

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -10,6 +10,7 @@ type Props = {|
   children: React$Node,
   debug?: boolean,
   stateManager?: Losen$StateManager,
+  onStepChanged: () => void,
   onValidationFailed: () => void,
 |};
 
@@ -18,6 +19,7 @@ const Wizard = ({
   onComplete,
   stateManager,
   debug,
+  onStepChanged,
   onValidationFailed,
 }: Props) => {
   const [index, setIndex] = useState<number | null>(null);
@@ -54,7 +56,10 @@ const Wizard = ({
     const nextAction =
       next === index
         ? () => onComplete(steps[index].name)
-        : () => setIndex(next);
+        : () => {
+            setIndex(next);
+            onStepChanged();
+          };
 
     if (validator) {
       setLoadingState(true);
@@ -84,6 +89,7 @@ const Wizard = ({
     }
     const prev = findPreviousValid(steps, index);
     setIndex(prev);
+    onStepChanged();
 
     if (stateManager) {
       const currentStep = steps[index];
@@ -146,6 +152,7 @@ const Wizard = ({
 Wizard.defaultProps = {
   debug: false,
   stateManager: undefined,
+  onStepChanged: () => {},
   onValidationFailed: () => {},
 };
 export default Wizard;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import Controls, { ControlsContext } from './Controls';
 import Step, { StepContext } from './Step';
-import Wizard, { ValidationError } from './Wizard';
+import Wizard from './Wizard';
 import { UrlStateManager } from './state-managers/url-state-manager';
 
 export {
@@ -9,7 +9,6 @@ export {
   ControlsContext,
   Step,
   StepContext,
-  ValidationError,
   Wizard,
   UrlStateManager,
 };


### PR DESCRIPTION
This PR changes how validation errors are handled in Losen.
Instead of throwing on validation fail, Losen simply moves to the next step if validation passes, and stays on the same step if validation fails.
If validation fails, the onValidationFailed event callback will be triggered, if available.

This PR also adds another event callback, onStepChanged which triggers when the step is changed.